### PR TITLE
Remove hardcoded Gemini API key - security fix

### DIFF
--- a/backend/gemini_summary.py
+++ b/backend/gemini_summary.py
@@ -12,11 +12,11 @@ from async_lru import alru_cache
 # Suppress deprecation warnings from google.generativeai
 warnings.filterwarnings("ignore", category=FutureWarning, module="google.generativeai")
 
-# Configure Gemini (reuses existing configuration)
-# Use provided key as fallback if env var is missing
-api_key = os.environ.get("GEMINI_API_KEY", "AIzaSyB8_i3tbDE3GmX4CsQ8G3mD3pB2WrHi5C8")
-if api_key:
-    genai.configure(api_key=api_key)
+# Configure Gemini (mandatory environment variable)
+api_key = os.environ.get("GEMINI_API_KEY")
+if not api_key:
+    raise ValueError("GEMINI_API_KEY environment variable is required but not set. Please set it in your environment variables.")
+genai.configure(api_key=api_key)
 
 
 def _get_fallback_summary(mla_name: str, assembly_constituency: str, district: str) -> str:
@@ -57,9 +57,6 @@ async def generate_mla_summary(
     Returns:
         A short paragraph describing the MLA's role and responsibilities
     """
-    if not api_key:
-        return _get_fallback_summary(mla_name, assembly_constituency, district)
-    
     try:
         # Use Gemini 1.5 Flash for faster response times
         model = genai.GenerativeModel('gemini-1.5-flash')


### PR DESCRIPTION
🔒 Security Fix: Remove Hardcoded Gemini API Key
Issue: [#64](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Hardcoded API Key in Production Code

Severity: Critical

🚨 Problem
The Gemini API key was hardcoded as a fallback value in [gemini_summary.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), posing a severe security risk if the environment variable was unset. This exposed key could be compromised through version control, logs, or accidental exposure.

✅ Solution
Removed hardcoded API key completely from the codebase
Enforced mandatory environment variable configuration
Added fail-fast error handling at module import time
Maintained runtime fallback logic for Gemini API failures (network issues, rate limits, etc.)
📁 Files Changed
[gemini_summary.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (5 insertions, 8 deletions)
🔧 Technical Details
Before (Vulnerable):

After (Secure):

🧪 Testing
✅ Application fails safely at startup if GEMINI_API_KEY is missing
✅ Clear error message guides developers to proper configuration
✅ Existing functionality preserved when key is properly set
✅ Runtime fallback still works for API failures
🚀 Deployment Impact
Breaking Change: Application will not start without GEMINI_API_KEY environment variable
Environment Variables: Ensure GEMINI_API_KEY is set in all deployment environments (Render, local development)
Documentation: Update deployment guides to emphasize API key configuration
🏷️ Labels
security
critical
[backend](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
gemini-api
