### PR TITLE
⚡ Bolt: Defer heavy columns in issue deduplication queries

### DIFF
--- a/backend/routers/issues.py
+++ b/backend/routers/issues.py
@@ -100,6 +100,10 @@ async def create_issue(
                     Issue.latitude <= max_lat,
                     Issue.longitude >= min_lon,
                     Issue.longitude <= max_lon
+                ).options(
+                    defer(Issue.action_plan),
+                    defer(Issue.image_path),
+                    defer(Issue.location)
                 ).all()
             )
 
@@ -261,6 +265,10 @@ def get_nearby_issues(
             Issue.latitude <= max_lat,
             Issue.longitude >= min_lon,
             Issue.longitude <= max_lon
+        ).options(
+            defer(Issue.action_plan),
+            defer(Issue.image_path),
+            defer(Issue.location)
         ).all()
 
         nearby_issues_with_distance = find_nearby_issues(


### PR DESCRIPTION
⚡ **Performance Optimization**

**What:**
Deferred `action_plan`, `image_path`, and `location` columns in `create_issue` (deduplication logic) and `get_nearby_issues` queries.

**Why:**
These endpoints fetch lists of issues to check for duplicates or display on a map. The `action_plan` field is a large JSON blob stored as TEXT, and `image_path` can be long. Fetching these for every candidate issue in a bounding box (even if filtered later by distance) wastes memory and DB bandwidth.

**Impact:**
- Reduces memory footprint for deduplication checks in dense areas.
- Reduces payload size from DB to App.
- Prevents loading of unused data.

**Verification:**
- Verified with a reproduction test case that the endpoints still return correct data (including `description` which is not deferred).
- Confirmed via code inspection that deferred fields are NOT accessed during `NearbyIssueResponse` construction, ensuring no N+1 query regression.

---
*PR created automatically by Jules for task [4160832973954895673](https://jules.google.com/task/4160832973954895673) started by @RohanExploit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database query performance for issue retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->