### PR TITLE
⚡ Bolt: Combine count queries in get_visit_statistics

### DIFF
--- a/backend/routers/field_officer.py
+++ b/backend/routers/field_officer.py
@@ -408,26 +408,23 @@ def get_visit_statistics(db: Session = Depends(get_db)):
     Returns metrics like total visits, verification status, geo-fence compliance, etc.
     """
     try:
-        # Use SQL aggregates instead of loading all visits into memory
-        total_visits = db.query(func.count(FieldOfficerVisit.id)).scalar() or 0
+        # Performance Boost: Consolidate multiple aggregate queries into a single database round trip
+        # This resolves the N+1 count query bottleneck documented in Bolt's journal
+        stats = db.query(
+            func.count(FieldOfficerVisit.id).label('total_visits'),
+            func.sum(case((FieldOfficerVisit.verified_at.isnot(None), 1), else_=0)).label('verified_visits'),
+            func.sum(case((FieldOfficerVisit.within_geofence == True, 1), else_=0)).label('within_geofence'),
+            func.sum(case((FieldOfficerVisit.within_geofence == False, 1), else_=0)).label('outside_geofence'),
+            func.count(func.distinct(FieldOfficerVisit.officer_email)).label('unique_officers'),
+            func.avg(FieldOfficerVisit.distance_from_site).label('average_distance')
+        ).first()
         
-        verified_visits = db.query(func.count(FieldOfficerVisit.id)).filter(
-            FieldOfficerVisit.verified_at.isnot(None)
-        ).scalar() or 0
-        
-        within_geofence_count = db.query(func.count(FieldOfficerVisit.id)).filter(
-            FieldOfficerVisit.within_geofence == True
-        ).scalar() or 0
-        
-        outside_geofence_count = db.query(func.count(FieldOfficerVisit.id)).filter(
-            FieldOfficerVisit.within_geofence == False
-        ).scalar() or 0
-        
-        unique_officers = db.query(func.count(func.distinct(FieldOfficerVisit.officer_email))).scalar() or 0
-        
-        average_distance = db.query(func.avg(FieldOfficerVisit.distance_from_site)).filter(
-            FieldOfficerVisit.distance_from_site.isnot(None)
-        ).scalar()
+        total_visits = stats.total_visits or 0
+        verified_visits = int(stats.verified_visits or 0)
+        within_geofence_count = int(stats.within_geofence or 0)
+        outside_geofence_count = int(stats.outside_geofence or 0)
+        unique_officers = stats.unique_officers or 0
+        average_distance = stats.average_distance
         
         # Round to 2 decimals if not None
         if average_distance is not None:


### PR DESCRIPTION
💡 What: Refactored `get_visit_statistics` in `backend/routers/field_officer.py` to calculate all visit metrics in a single database query using SQL aggregations.
🎯 Why: The original implementation executed 6 separate queries (5 counts, 1 avg) which scales poorly. Combining them eliminates redundant database round-trips.
📊 Impact: Reduces database queries from 6 to 1 per endpoint call, significantly improving latency and reducing database load.
🔬 Measurement: Verify by executing the `/api/field-officer/visit-stats` endpoint and checking the application logs or running the test suite `PYTHONPATH=. pytest backend/tests/`.

---
*PR created automatically by Jules for task [2447378373000461510](https://jules.google.com/task/2447378373000461510) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combined all visit metrics in get_visit_statistics into one SQL aggregate query, cutting 6 queries to 1 to speed up /api/field-officer/visit-stats.
No app code changes were introduced in the latest deployment-related commit.

<sup>Written for commit b4ab2381e43e5aa88c65229ed2316cf75dbff95a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized visit statistics database queries for improved performance and faster load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->