### PR TITLE
fix: exit process after dailyRefinementJob finishes

### DIFF
--- a/scheduler/dailyRefinementJob.ts
+++ b/scheduler/dailyRefinementJob.ts
@@ -131,7 +131,12 @@ if (require.main === module) {
 
   // For testing/manual trigger, we can also pass a flag or just run immediately if needed
   if (process.argv.includes("--run-now")) {
-    job.runRefinement();
+    job.runRefinement().then(() => {
+      process.exit(0);
+    }).catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
   }
 }
 // Implementation is complete and verified.


### PR DESCRIPTION
Fixes an issue where `scheduler/dailyRefinementJob.ts` hangs indefinitely when executed with the `--run-now` flag. The script now awaits the refinement job and explicitly calls `process.exit(0)` on success or `process.exit(1)` on error.

---
*PR created automatically by Jules for task [6153720936118833140](https://jules.google.com/task/6153720936118833140) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang when running `scheduler/dailyRefinementJob.ts` with `--run-now` by awaiting the refinement job. The script now exits with code 0 on success or 1 on error, preventing runaway processes in manual/CI runs.

<sup>Written for commit bdcb6fd72970db8b3f6daa081d9de4bed12a62ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced manual job execution to properly handle errors and ensure correct process termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->