### PR TITLE
Fix backend tests and optimize data structures

### DIFF
--- a/backend/routers/utility.py
+++ b/backend/routers/utility.py
@@ -71,7 +71,8 @@ def get_stats(db: Session = Depends(get_db)):
         resolved += int(cat_resolved or 0)
 
         # Build category breakdown
-        issues_by_category[cat] = cat_total or 0
+        if cat:
+            issues_by_category[cat] = cat_total or 0
 
     # Pending is everything else
     pending = total - resolved
@@ -142,12 +143,12 @@ def get_leaderboard(db: Session = Depends(get_db)):
         except Exception:
             masked_email = "User***"
 
-        leaderboard_data.append(LeaderboardEntry(
-            user_email=masked_email,
-            reports_count=count,
-            total_upvotes=upvotes or 0,
-            rank=idx + 1
-        ).model_dump(mode='json'))
+        leaderboard_data.append({
+            "user_email": masked_email,
+            "reports_count": count,
+            "total_upvotes": upvotes or 0,
+            "rank": idx + 1
+        })
 
     response_data = {"leaderboard": leaderboard_data}
     json_data = json.dumps(response_data)

--- a/backend/tests/test_detection_bytes.py
+++ b/backend/tests/test_detection_bytes.py
@@ -65,8 +65,7 @@ def client():
             backend.dependencies.SHARED_HTTP_CLIENT = mock_client
             yield c
 
-@pytest.mark.asyncio
-async def test_detect_vandalism_with_bytes(client):
+def test_detect_vandalism_with_bytes(client):
     # We need to control the response for specific tests
     # Since client is fixture, the http_client is already initialized in app.state
     # We can access it via app.state.http_client (which is the mock_client from fixture)
@@ -104,8 +103,7 @@ async def test_detect_vandalism_with_bytes(client):
 
     # Client not invoked because detection is mocked above
 
-@pytest.mark.asyncio
-async def test_detect_infrastructure_with_bytes(client):
+def test_detect_infrastructure_with_bytes(client):
     mock_client = app.state.http_client
     mock_client.post.reset_mock()
 

--- a/backend/tests/test_new_detectors.py
+++ b/backend/tests/test_new_detectors.py
@@ -56,8 +56,7 @@ def create_test_image():
     img.save(img_byte_arr, format='JPEG')
     return img_byte_arr.getvalue()
 
-@pytest.mark.asyncio
-async def test_detect_traffic_sign_damaged(client):
+def test_detect_traffic_sign_damaged(client):
     # Mock the HF API response at the lower level (_make_request or query_hf_api)
     # Since we are mocking the client, we mock the client.post response
 
@@ -86,8 +85,7 @@ async def test_detect_traffic_sign_damaged(client):
     assert len(data["detections"]) == 1
     assert data["detections"][0]["label"] == "damaged traffic sign"
 
-@pytest.mark.asyncio
-async def test_detect_traffic_sign_clear(client):
+def test_detect_traffic_sign_clear(client):
     img_bytes = create_test_image()
 
     with patch('backend.utils.validate_uploaded_file'), \
@@ -102,8 +100,7 @@ async def test_detect_traffic_sign_clear(client):
     # Should be empty because 'clear traffic sign' is not in targets
     assert len(data["detections"]) == 0
 
-@pytest.mark.asyncio
-async def test_detect_abandoned_vehicle_found(client):
+def test_detect_abandoned_vehicle_found(client):
     img_bytes = create_test_image()
 
     with patch('backend.utils.validate_uploaded_file'), \

--- a/backend/tests/test_severity.py
+++ b/backend/tests/test_severity.py
@@ -35,8 +35,7 @@ sys.modules['telegram.ext'] = mock_telegram.ext
 
 from backend.main import app
 
-@pytest.mark.asyncio
-async def test_detect_severity_endpoint():
+def test_detect_severity_endpoint():
     # Mock AI services initialization to prevent startup failure
     with patch('backend.main.create_all_ai_services') as mock_create_services, \
          patch('backend.main.initialize_ai_services') as mock_init_services, \


### PR DESCRIPTION
Fixed backend test failures caused by async/await mismatches with TestClient in `backend/tests/test_detection_bytes.py`, `backend/tests/test_new_detectors.py`, and `backend/tests/test_severity.py`. Also optimized dictionary initialization loop in `backend/routers/utility.py` to avoid Pydantic object overhead before json dumps, and fixed a potential NoneKey error in the `get_stats` category assignment.

---
*PR created automatically by Jules for task [2196099096344483541](https://jules.google.com/task/2196099096344483541) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing backend tests by aligning them with sync `TestClient` usage, and reduces JSON serialization overhead in `backend/routers/utility.py`. Also guards against missing categories in stats to prevent errors.

- **Bug Fixes**
  - Converted async tests to sync by removing `@pytest.mark.asyncio` and `async def` in `backend/tests/test_detection_bytes.py`, `backend/tests/test_new_detectors.py`, and `backend/tests/test_severity.py`.
  - Avoided a None key in `get_stats` by checking `cat` before adding to `issues_by_category`.

- **Refactors**
  - Built leaderboard entries as plain dicts instead of Pydantic models (`LeaderboardEntry.model_dump`) before `json.dumps` to reduce overhead.

<sup>Written for commit dd66cc84a97664160a9f191b6e0c9584dce46645. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Stats endpoint now properly filters out entries with null or empty categories.

* **Refactor**
  * Optimized leaderboard data structure handling for improved performance.
  * Updated internal test execution model for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->