### PR TITLE
Optimize closure service aggregate query using case conditional statements

### DIFF
--- a/backend/closure_service.py
+++ b/backend/closure_service.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Session
-from sqlalchemy import func
+from sqlalchemy import func, case
 from datetime import datetime, timedelta, timezone
 from backend.models import Grievance, GrievanceFollower, ClosureConfirmation, GrievanceStatus
 import logging
@@ -112,14 +112,13 @@ class ClosureService:
         ).scalar()
         
         # Get all confirmation counts in a single query instead of multiple round-trips
-        counts = db.query(
-            ClosureConfirmation.confirmation_type,
-            func.count(ClosureConfirmation.id).label("count")
-        ).filter(ClosureConfirmation.grievance_id == grievance_id).group_by(ClosureConfirmation.confirmation_type).all()
+        stats = db.query(
+            func.sum(case((ClosureConfirmation.confirmation_type == 'confirmed', 1), else_=0)).label('confirmed'),
+            func.sum(case((ClosureConfirmation.confirmation_type == 'disputed', 1), else_=0)).label('disputed')
+        ).filter(ClosureConfirmation.grievance_id == grievance_id).first()
         
-        counts_dict = {ctype: count for ctype, count in counts}
-        confirmations_count = counts_dict.get("confirmed", 0)
-        disputes_count = counts_dict.get("disputed", 0)
+        confirmations_count = stats.confirmed or 0
+        disputes_count = stats.disputed or 0
         
         required_confirmations = max(1, int(total_followers * ClosureService.CONFIRMATION_THRESHOLD))
         


### PR DESCRIPTION
This change optimizes the database query in `ClosureService.check_and_finalize_closure` by using conditional aggregation (`func.sum(case(...))`) instead of `group_by`. This reduces processing overhead in Python by directly fetching the required `confirmed` and `disputed` counts, matching the established optimization convention found in other parts of the repository (e.g., `admin.py`, `field_officer.py`, `grievances.py`). Tests were verified locally to ensure no regressions.

---
*PR created automatically by Jules for task [12981223836317441333](https://jules.google.com/task/12981223836317441333) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized `ClosureService.check_and_finalize_closure` by replacing a grouped count with conditional aggregates (`func.sum(case(...))`) to compute `confirmed` and `disputed` in a single row. This reduces Python-side work, avoids `GROUP BY`, and adds the `case` import for a small performance win.

<sup>Written for commit a179ad4646ebe8b9a51f84bb6444fa47a48f2af6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal query logic for closure confirmation and dispute counting to improve database efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->