### PR TITLE
⚡ Bolt: [performance improvement] Optimize grievance query to use load_only

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 ## 2026-04-20 - Async File I/O in Voice Submission
 **Learning:** Saving audio recordings (up to 10MB) synchronously in a FastAPI async endpoint blocks the main event loop, significantly increasing tail latency for all concurrent users during high-traffic periods.
 **Action:** Wrap blocking synchronous File I/O operations like `f.write()` in `run_in_threadpool` to offload them to a separate thread, keeping the event loop responsive for other requests.
+
+## 2026-05-18 - Mocking SQLAlchemy load_only options
+**Learning:** When changing a database query from `db.query(Model)` to `db.query(Model).options(load_only(...))` to optimize data fetching, the return type remains the ORM model (unlike column projection which returns tuples). However, if the tests mock the SQLAlchemy query chain, the mock assertions will fail because `.options()` is added to the chain.
+**Action:** When adding `.options(load_only(...))` to a query, always ensure the corresponding mock queries in tests are updated to include `.options.return_value` (e.g., `mock_query.options.return_value.filter.return_value.all.return_value = ...`) to correctly mock the new chain.

--- a/backend/civic_intelligence.py
+++ b/backend/civic_intelligence.py
@@ -3,7 +3,7 @@ import os
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Any
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, load_only
 from sqlalchemy import func
 
 from backend.models import Issue, EscalationAudit, EscalationReason, Grievance
@@ -88,7 +88,8 @@ class CivicIntelligenceEngine:
             # Optimization: Fetch all related grievances in one query to avoid N+1
             grievance_ids = [audit.grievance_id for audit in upgrades]
             if grievance_ids:
-                grievances = db.query(Grievance).filter(Grievance.id.in_(grievance_ids)).all()
+                # Optimized: Use load_only to avoid fetching unnecessary columns while preserving ORM objects
+                grievances = db.query(Grievance).options(load_only(Grievance.id, Grievance.category)).filter(Grievance.id.in_(grievance_ids)).all()
                 grievance_map = {g.id: g for g in grievances}
             else:
                 grievance_map = {}

--- a/backend/tests/test_civic_intelligence.py
+++ b/backend/tests/test_civic_intelligence.py
@@ -190,6 +190,7 @@ def test_civic_intelligence_run(mock_listdir, mock_json_dump, mock_file_open, mo
     g1 = Grievance(id=1, category="Fire")
     g2 = Grievance(id=2, category="Fire")
     g3 = Grievance(id=3, category="Fire")
+    mock_query_grievance.options.return_value.filter.return_value.all.return_value = [g1, g2, g3]
     mock_query_grievance.filter.return_value.all.return_value = [g1, g2, g3]
 
     # Setup Trend Analyzer


### PR DESCRIPTION
💡 What: Replaced full ORM loading of the Grievance model with `.options(load_only(Grievance.id, Grievance.category))` in the daily civic intelligence job.
🎯 Why: Selecting full SQLAlchemy model instances is slower and uses more memory, especially as the number of upgrades scales up, and only the id and category fields were needed.
📊 Impact: Reduces memory usage and database I/O for fetching associated grievances by avoiding loading unnecessary fields like `action_plan` and `description` while maintaining the ORM object structure.
🔬 Measurement: Verified that all 107 tests pass in the backend suite and the logic correctly interacts with the object properties.

---
*PR created automatically by Jules for task [4290250909438725555](https://jules.google.com/task/4290250909438725555) started by @RohanExploit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized the grievance data loading process to retrieve only essential information instead of fetching all available fields, reducing memory overhead and improving overall performance during the daily processing cycle.

* **Tests**
  * Updated test cases to accurately reflect the changes to the grievance query logic and ensure proper coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized the grievance lookup in the daily civic intelligence job by using SQLAlchemy `load_only` to fetch only `id` and `category`. This reduces DB I/O and memory; tests now mock the `.options(...).filter().all()` chain to cover the new query path.

<sup>Written for commit fbe885fe2d9e1f44b94a4c21b1ece97055617418. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

