### PR TITLE
Fix cache `.set()` kwargs usage

### DIFF
--- a/backend/main_fixed.py
+++ b/backend/main_fixed.py
@@ -393,7 +393,7 @@ async def create_issue(
             if len(current_cache) > 10:
                 current_cache.pop()
 
-            recent_issues_cache.set(current_cache)
+            recent_issues_cache.set(data=current_cache)
     except Exception as e:
         logger.error(f"Error updating cache optimistically: {e}")
         # Failure to update cache is not critical, don't fail the request
@@ -492,7 +492,7 @@ def get_recent_issues(db: Session = Depends(get_db)):
             action_plan=i.action_plan
         ).model_dump(mode='json'))
 
-    recent_issues_cache.set(data)
+    recent_issues_cache.set(data=data)
     return data
 
 # FIXED: Standardized Detection Endpoints with Consistent Validation

--- a/backend/routers/utility.py
+++ b/backend/routers/utility.py
@@ -85,7 +85,7 @@ def get_stats(db: Session = Depends(get_db)):
 
     data = response.model_dump(mode='json')
     json_data = json.dumps(data)
-    recent_issues_cache.set(json_data, "stats")
+    recent_issues_cache.set(data=json_data, key="stats")
 
     return Response(content=json_data, media_type="application/json")
 
@@ -153,7 +153,7 @@ def get_leaderboard(db: Session = Depends(get_db)):
     response_data = {"leaderboard": leaderboard_data}
     json_data = json.dumps(response_data)
     # Cache for 5 minutes to reduce DB load on frequent hits
-    recent_issues_cache.set(json_data, cache_key)
+    recent_issues_cache.set(data=json_data, key=cache_key)
 
     return Response(content=json_data, media_type="application/json")
 

--- a/backend/tests/test_cache_unit.py
+++ b/backend/tests/test_cache_unit.py
@@ -4,14 +4,14 @@ from backend.cache import ThreadSafeCache
 
 def test_cache_set_get():
     cache = ThreadSafeCache(ttl=60, max_size=10)
-    cache.set("value1", "key1")
+    cache.set(data="value1", key="key1")
     assert cache.get("key1") == "value1"
     assert cache.get("key2") is None
 
 def test_cache_expiration():
     # Cache with 0 TTL should expire immediately
     cache = ThreadSafeCache(ttl=0, max_size=10)
-    cache.set("value1", "key1")
+    cache.set(data="value1", key="key1")
     # Small sleep to ensure time.time() might move a bit if resolution allows,
     # but with ttl=0 it should expire if we call get() even slightly after set()
     # Actually _cleanup_expired uses >= ttl
@@ -19,9 +19,9 @@ def test_cache_expiration():
 
 def test_cache_lru_eviction():
     cache = ThreadSafeCache(ttl=60, max_size=2)
-    cache.set("v1", "k1")
-    cache.set("v2", "k2")
-    cache.set("v3", "k3") # Should evict k1
+    cache.set(data="v1", key="k1")
+    cache.set(data="v2", key="k2")
+    cache.set(data="v3", key="k3") # Should evict k1
 
     assert cache.get("k1") is None
     assert cache.get("k2") == "v2"
@@ -29,9 +29,9 @@ def test_cache_lru_eviction():
 
 def test_cache_cleanup_logic():
     cache = ThreadSafeCache(ttl=1, max_size=10)
-    cache.set("v1", "k1")
+    cache.set(data="v1", key="k1")
     time.sleep(1.1)
-    cache.set("v2", "k2") # Should trigger cleanup of k1
+    cache.set(data="v2", key="k2") # Should trigger cleanup of k1
 
     stats = cache.get_stats()
     # total_entries might still be 1 if cleanup worked
@@ -40,9 +40,9 @@ def test_cache_cleanup_logic():
 
 def test_cache_ordered_cleanup():
     cache = ThreadSafeCache(ttl=1, max_size=10)
-    cache.set("v1", "k1")
+    cache.set(data="v1", key="k1")
     time.sleep(0.5)
-    cache.set("v2", "k2")
+    cache.set(data="v2", key="k2")
     time.sleep(0.6)
     # k1 is now > 1.1s old (expired)
     # k2 is now 0.6s old (not expired)

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -61,7 +61,7 @@ def check_upload_limits(identifier: str, limit: int) -> None:
 
     # Add current timestamp and update cache atomically
     recent_uploads.append(now)
-    user_upload_cache.set(recent_uploads, identifier)
+    user_upload_cache.set(data=recent_uploads, key=identifier)
 
 def _validate_uploaded_file_sync(file: UploadFile) -> Optional[Image.Image]:
     """


### PR DESCRIPTION
Fix `ThreadSafeCache.set` calls across the codebase to correctly use explicit keyword arguments (`data=` and `key=`), preventing potential bugs and ensuring correct cache population.

---
*PR created automatically by Jules for task [17410130062223211849](https://jules.google.com/task/17410130062223211849) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed all `ThreadSafeCache.set` calls to use explicit `data=` and `key=` kwargs, preventing swapped arguments and broken cache entries. This stabilizes caching for recent issues, stats/leaderboard responses, and upload limits.

- **Bug Fixes**
  - Standardized cache writes in `backend/main_fixed.py`, `backend/routers/utility.py`, and `backend/utils.py`.
  - Updated unit tests to use the new signature and verify expiration/eviction behavior.

<sup>Written for commit a156c232ebb2e0f050613dbf33f2af7521b87422. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal cache function call signatures across multiple modules for improved code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->