### PR TITLE
Fix tests and thread safety in model loading

### DIFF
--- a/backend/pothole_detection.py
+++ b/backend/pothole_detection.py
@@ -129,13 +129,6 @@ def reset_model():
         _model_loading_error = None
         logger.info("Model singleton state has been reset.")
 
-    if _model is None:
-        with _model_lock:
-            if _model is None:  # Double check inside lock
-                try:
-                    _model = load_model()
-                except Exception:
-                    pass
     return _model
 
 def detect_potholes(image_source):

--- a/tests/test_captioning.py
+++ b/tests/test_captioning.py
@@ -3,6 +3,15 @@ from unittest.mock import patch, AsyncMock
 from backend.main import app
 import pytest
 
+import io
+from PIL import Image
+
+def create_test_image():
+    img = Image.new('RGB', (100, 100), color='red')
+    img_byte_arr = io.BytesIO()
+    img.save(img_byte_arr, format='JPEG')
+    return img_byte_arr.getvalue()
+
 @pytest.mark.asyncio
 async def test_generate_description_endpoint():
     # Mock the generate_image_caption function in 'backend.routers.detection' module
@@ -11,7 +20,7 @@ async def test_generate_description_endpoint():
 
         with TestClient(app) as client:
             # Create a dummy image
-            file_content = b"fake image content"
+            file_content = create_test_image()
             files = {"image": ("test.jpg", file_content, "image/jpeg")}
 
             response = client.post("/api/generate-description", files=files)

--- a/tests/test_graffiti_endpoint.py
+++ b/tests/test_graffiti_endpoint.py
@@ -2,8 +2,16 @@ from fastapi.testclient import TestClient
 from unittest.mock import patch
 from backend.main import app
 import pytest
+import io
+from PIL import Image
 
 client = TestClient(app)
+
+def create_test_image():
+    img = Image.new('RGB', (100, 100), color='red')
+    img_byte_arr = io.BytesIO()
+    img.save(img_byte_arr, format='JPEG')
+    return img_byte_arr.getvalue()
 
 @pytest.fixture
 def mock_detect_graffiti():
@@ -24,7 +32,7 @@ def test_detect_graffiti(mock_detect_graffiti, mock_validate_file):
     ]
 
     # Simple dummy bytes
-    files = {"image": ("test.jpg", b"fake_image_bytes", "image/jpeg")}
+    files = {"image": ("test.jpg", create_test_image(), "image/jpeg")}
 
     response = client.post("/api/detect-graffiti", files=files)
 

--- a/tests/test_smart_scan.py
+++ b/tests/test_smart_scan.py
@@ -2,6 +2,14 @@ from fastapi.testclient import TestClient
 from unittest.mock import patch, AsyncMock
 from backend.main import app
 import pytest
+import io
+from PIL import Image
+
+def create_test_image():
+    img = Image.new('RGB', (100, 100), color='red')
+    img_byte_arr = io.BytesIO()
+    img.save(img_byte_arr, format='JPEG')
+    return img_byte_arr.getvalue()
 
 def test_smart_scan_endpoint():
     with TestClient(app) as client:
@@ -9,7 +17,7 @@ def test_smart_scan_endpoint():
         with patch("backend.routers.detection.detect_smart_scan_clip", new_callable=AsyncMock) as mock_detect:
             mock_detect.return_value = {"category": "pothole", "confidence": 0.95}
 
-            file_content = b"fakeimagebytes"
+            file_content = create_test_image()
 
             response = client.post(
                 "/api/detect-smart-scan",

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -29,8 +29,8 @@ def test_root_endpoint():
     
     assert response.status_code == 200
     json_response = response.json()
-    assert "data" in json_response
-    assert json_response["data"]["service"] == "VishwaGuru API"
+    assert "status" in json_response
+    assert json_response["service"] == "VishwaGuru API"
 
 if __name__ == "__main__":
     print("Testing startup and port binding...")

--- a/tests/test_vandalism.py
+++ b/tests/test_vandalism.py
@@ -14,8 +14,8 @@ def test_read_main(client):
     response = client.get("/")
     assert response.status_code == 200
     json_response = response.json()
-    assert "data" in json_response
-    assert json_response["data"]["service"] == "VishwaGuru API"
+    assert "status" in json_response
+    assert json_response["service"] == "VishwaGuru API"
 
 @patch("backend.utils.magic.from_buffer")
 @patch("backend.routers.detection.detect_vandalism_unified", new_callable=AsyncMock)


### PR DESCRIPTION
Fix tests and thread safety in model loading

- Fix test failures in backend where valid image bytes are needed for mock testing.
- Fix tests pointing to root endpoint response structure.
- Remove invalid duplicate thread loading logic inside reset_model in pothole_detection.py

---
*PR created automatically by Jules for task [18032107273216927269](https://jules.google.com/task/18032107273216927269) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing backend tests and removes a thread-safety issue in model loading to stabilize CI and runtime. Tests now use valid JPEG bytes and root endpoint assertions match the current response.

- **Bug Fixes**
  - Use real in-memory JPEGs in image upload tests to satisfy file validation.
  - Update root endpoint tests to expect top-level "status" and "service".
  - Remove duplicate model loading inside reset_model so it only clears state, avoiding races and double loads.

<sup>Written for commit 929b94032faebc177e80ce0b843a1f54a8320b5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model initialization logic to prevent repeated failed loading attempts and properly raise cached initialization errors.

* **Tests**
  * Updated test assertions to reflect API response format changes with top-level `status` field.
  * Enhanced image handling in tests with real JPEG image generation for improved test reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RohanExploit/VishwaGuru/pull/749)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->