### PR TITLE
feat: add blockchain integrity fields to ResolutionProofToken

### DIFF
--- a/backend/cache.py
+++ b/backend/cache.py
@@ -180,6 +180,7 @@ user_upload_cache = ThreadSafeCache(ttl=3600, max_size=1000)  # 1 hour TTL for u
 blockchain_last_hash_cache = ThreadSafeCache(ttl=3600, max_size=1)
 grievance_last_hash_cache = ThreadSafeCache(ttl=3600, max_size=1)
 resolution_last_hash_cache = ThreadSafeCache(ttl=3600, max_size=1)
+token_last_hash_cache = ThreadSafeCache(ttl=3600, max_size=1)
 visit_last_hash_cache = ThreadSafeCache(ttl=3600, max_size=2)
 audit_last_hash_cache = ThreadSafeCache(ttl=3600, max_size=2)
 evidence_audit_last_hash_cache = ThreadSafeCache(ttl=3600, max_size=1)

--- a/backend/models.py
+++ b/backend/models.py
@@ -323,6 +323,10 @@ class ResolutionProofToken(Base):
     valid_from = Column(DateTime, nullable=True)
     valid_until = Column(DateTime, nullable=True)
 
+    # Blockchain integrity fields
+    integrity_hash = Column(String, nullable=True)
+    previous_integrity_hash = Column(String, nullable=True, index=True)
+
     # Relationship
     grievance = relationship("Grievance", back_populates="resolution_tokens")
 

--- a/backend/resolution_proof_service.py
+++ b/backend/resolution_proof_service.py
@@ -26,7 +26,7 @@ from backend.models import (
     EvidenceAuditLog, VerificationStatus, GrievanceStatus
 )
 from backend.config import get_config, get_auth_config
-from backend.cache import resolution_last_hash_cache, evidence_audit_last_hash_cache
+from backend.cache import resolution_last_hash_cache, evidence_audit_last_hash_cache, token_last_hash_cache
 
 logger = logging.getLogger(__name__)
 
@@ -189,6 +189,22 @@ class ResolutionProofService:
 
         signature = ResolutionProofService._sign_payload(payload)
 
+        # Generate Integrity Hash
+        prev_hash = token_last_hash_cache.get("last_hash")
+        if prev_hash is None:
+            # Cache miss: Fetch only the last hash from DB
+            last_record = db.query(ResolutionProofToken.integrity_hash).order_by(ResolutionProofToken.id.desc()).first()
+            prev_hash = last_record[0] if last_record and last_record[0] else ""
+            token_last_hash_cache.set(data=prev_hash, key="last_hash")
+
+        hash_content = f"{token_uuid}|{grievance_id}|{authority_email}|{now.isoformat()}|{prev_hash}"
+        secret_key = get_auth_config().secret_key
+        integrity_hash = hmac.new(
+            secret_key.encode('utf-8'),
+            hash_content.encode('utf-8'),
+            hashlib.sha256
+        ).hexdigest()
+
         # Create token record
         token = ResolutionProofToken(
             token_id=token_uuid,
@@ -203,11 +219,15 @@ class ResolutionProofService:
             nonce=nonce,
             token_signature=signature,
             is_used=False,
+            integrity_hash=integrity_hash,
+            previous_integrity_hash=prev_hash,
         )
 
         db.add(token)
         db.commit()
         db.refresh(token)
+
+        token_last_hash_cache.set(data=integrity_hash, key="last_hash")
 
         logger.info(
             f"Generated RPT {token_uuid} for grievance {grievance_id} "


### PR DESCRIPTION
Added `integrity_hash` and `previous_integrity_hash` to the `ResolutionProofToken` model to maintain standard blockchain-style integrity chaining across core entities. Implemented a `token_last_hash_cache` in `backend/cache.py` to prevent redundant database queries and securely generate hashes using HMAC-SHA256 in `backend/resolution_proof_service.py` without degrading performance.

---
*PR created automatically by Jules for task [8330752688685032256](https://jules.google.com/task/8330752688685032256) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds blockchain-style integrity chaining to `ResolutionProofToken`. Generates HMAC-SHA256 hashes and caches the last hash to avoid extra DB reads.

- **New Features**
  - Added `integrity_hash` and `previous_integrity_hash` (indexed) to `ResolutionProofToken` for chain linking.
  - Implemented `token_last_hash_cache` to store the last hash (TTL 1h, size 1) and reduce queries.
  - Hash content includes token ID, grievance ID, authority email, timestamp, and previous hash; signed with the auth `secret_key`.
  - Backwards compatible: new fields are nullable; existing records remain unchanged.

- **Migration**
  - Add nullable columns `integrity_hash` and `previous_integrity_hash` to the `ResolutionProofToken` table.
  - No backfill required; the chain starts with the next issued token.

<sup>Written for commit 08318aa73c6e80d4300603a69c2834249579d2c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced resolution proof tokens with built-in integrity verification using cryptographic hashing.
  * Tokens now maintain a complete integrity chain to ensure authenticity and prevent tampering throughout their lifecycle.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RohanExploit/VishwaGuru/pull/753)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->