### PR TITLE
Fix orphaned file uploads in deduplication and fix frontend test environment

### DIFF
--- a/backend/routers/issues.py
+++ b/backend/routers/issues.py
@@ -215,6 +215,13 @@ async def create_issue(
         else:
             # Don't create new issue, just return deduplication info
             new_issue = None
+
+            # Clean up uploaded file if it was discarded as duplicate
+            if image_path and os.path.exists(image_path):
+                try:
+                    os.remove(image_path)
+                except OSError:
+                    pass  # Ignore cleanup errors
     except Exception as e:
         # Clean up uploaded file if DB save failed
         if image_path and os.path.exists(image_path):


### PR DESCRIPTION
This PR addresses an issue where uploaded images would be left orphaned on disk if an issue report was flagged as a duplicate by the spatial deduplication system. It safely deletes these temp files.
It also fixes a missing dependency `jest-environment-jsdom` in `frontend` that was causing frontend tests to fail.

---
*PR created automatically by Jules for task [8947891066862357910](https://jules.google.com/task/8947891066862357910) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents orphaned image uploads when deduplication links a report to an existing issue, and restores frontend test stability by adding `jest-environment-jsdom`.

- **Bug Fixes**
  - Delete temp image files when a report is flagged as a duplicate to avoid leftovers on disk.
  - Add missing `jest-environment-jsdom` in `frontend` to fix failing tests.

<sup>Written for commit f69842fe4eefd792a39dc7294a88b76e0a7dc8a7. Summary will update on new commits. <a href="https://cubic.dev/pr/RohanExploit/VishwaGuru/pull/779?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue handling to properly clean up uploaded image files when a duplicate issue is detected in the same location. Cleanup errors are now handled gracefully to prevent service disruptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RohanExploit/VishwaGuru/pull/779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->