### PR TITLE
⚡ Bolt: Resolve N+1 query in grievance escalation loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2025-07-15 - Fast Bounding Box Pre-filter
 **Learning:** Calculating great circle distance (Haversine) for every issue against a target location is computationally expensive (O(N) with heavy math ops like sin, cos, atan2). In high-traffic aggregations, this can become a bottleneck.
 **Action:** Use a fast bounding box pre-filter (`get_bounding_box` with a 5% epsilon) to quickly discard issues that are definitely outside the search radius before running the expensive exact haversine distance calculation.
+
+## 2025-07-16 - N+1 Query in Escalation Loop
+**Learning:** During periodic evaluation of overdue grievances (`evaluate_and_escalate_grievances`), checking `grievance.jurisdiction.level` without eager loading triggers a separate DB query for every overdue grievance. This is a classic N+1 bottleneck when scanning a large number of open issues.
+**Action:** Always use `.options(joinedload(Model.relationship))` in queries that retrieve lists of items if those items' relationships will be accessed during iteration.

--- a/backend/escalation_engine.py
+++ b/backend/escalation_engine.py
@@ -5,7 +5,7 @@ Core engine for evaluating and performing grievance escalations based on SLA and
 
 import datetime
 from typing import List, Dict, Any, Optional
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import and_, or_
 from backend.models import Grievance, Jurisdiction, EscalationAudit, GrievanceStatus, JurisdictionLevel, EscalationReason, SeverityLevel
 from backend.database import SessionLocal
@@ -150,7 +150,10 @@ class EscalationEngine:
         now = datetime.datetime.now(datetime.timezone.utc)
 
         # Get grievances that are active and past SLA deadline
-        return db.query(Grievance).filter(
+        # PERFORMANCE OPTIMIZATION:
+        # Added .options(joinedload(Grievance.jurisdiction)) to resolve an N+1 query problem.
+        # This prevents a separate database query for each jurisdiction during the evaluation loop.
+        return db.query(Grievance).options(joinedload(Grievance.jurisdiction)).filter(
             and_(
                 Grievance.status.in_([GrievanceStatus.OPEN, GrievanceStatus.IN_PROGRESS, GrievanceStatus.ESCALATED]),
                 Grievance.sla_deadline < now


### PR DESCRIPTION
💡 **What:** 
Added `joinedload(Grievance.jurisdiction)` to the `_get_grievances_for_evaluation` SQLAlchemy query in `backend/escalation_engine.py`.

🎯 **Why:** 
During the periodic evaluation of overdue grievances (`evaluate_and_escalate_grievances`), the engine loops over all overdue grievances and accesses `grievance.jurisdiction.level` in `_should_escalate`. Without eager loading, this resulted in a classic N+1 query problem, firing an additional database query for every single overdue grievance, which is a major bottleneck as the database grows.

📊 **Impact:** 
Reduces the number of database queries in the evaluation loop from N+1 (where N is the number of overdue grievances) to exactly 1. This significantly improves the execution speed of the periodic cron job and reduces database load.

🔬 **Measurement:** 
Enable SQLAlchemy query logging (e.g., `echo=True` on engine creation) and run `evaluate_and_escalate_grievances`. Verify that only a single SQL query is executed instead of one large query followed by many smaller ones fetching jurisdictions. Tests continue to pass.

---
*PR created automatically by Jules for task [1610573002636816145](https://jules.google.com/task/1610573002636816145) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates an N+1 query in the grievance escalation loop by eager-loading jurisdictions via `joinedload(Grievance.jurisdiction)` in `_get_grievances_for_evaluation`. This reduces DB queries from N+1 to 1 and speeds up the periodic evaluation job while lowering database load.

<sup>Written for commit 90922f2e33ae0fde9750e72b44c5807c95390dca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RohanExploit/VishwaGuru/pull/913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved overdue grievance evaluation by loading jurisdiction details more efficiently.
  * Reduced unnecessary database requests during escalation processing.

* **Documentation**
  * Added guidance documenting the resolved query performance issue and recommended approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->