### PR TITLE
⚡ Bolt: [performance improvement] Eager load jurisdiction in EscalationEngine

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2025-07-15 - Fast Bounding Box Pre-filter
 **Learning:** Calculating great circle distance (Haversine) for every issue against a target location is computationally expensive (O(N) with heavy math ops like sin, cos, atan2). In high-traffic aggregations, this can become a bottleneck.
 **Action:** Use a fast bounding box pre-filter (`get_bounding_box` with a 5% epsilon) to quickly discard issues that are definitely outside the search radius before running the expensive exact haversine distance calculation.
+
+## 2024-05-31 - N+1 Query in Escalation Engine
+**Learning:** During periodic grievance evaluation, the escalation engine fetches all grievances past their SLA. However, when evaluating if each grievance can be escalated (`grievance.jurisdiction.level`), an additional database query is fired for *each* grievance to load its associated jurisdiction. This N+1 query problem significantly degrades performance as the number of overdue grievances grows.
+**Action:** Use SQLAlchemy's `joinedload(Grievance.jurisdiction)` in `_get_grievances_for_evaluation` to eagerly load the jurisdiction data in the initial query, eliminating the N+1 bottleneck.

--- a/backend/escalation_engine.py
+++ b/backend/escalation_engine.py
@@ -5,7 +5,7 @@ Core engine for evaluating and performing grievance escalations based on SLA and
 
 import datetime
 from typing import List, Dict, Any, Optional
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import and_, or_
 from backend.models import Grievance, Jurisdiction, EscalationAudit, GrievanceStatus, JurisdictionLevel, EscalationReason, SeverityLevel
 from backend.database import SessionLocal
@@ -150,7 +150,8 @@ class EscalationEngine:
         now = datetime.datetime.now(datetime.timezone.utc)
 
         # Get grievances that are active and past SLA deadline
-        return db.query(Grievance).filter(
+        # Eagerly load jurisdiction to prevent N+1 queries during evaluation
+        return db.query(Grievance).options(joinedload(Grievance.jurisdiction)).filter(
             and_(
                 Grievance.status.in_([GrievanceStatus.OPEN, GrievanceStatus.IN_PROGRESS, GrievanceStatus.ESCALATED]),
                 Grievance.sla_deadline < now


### PR DESCRIPTION
💡 What: Eagerly load `jurisdiction` relationship when fetching overdue grievances.
🎯 Why: `_should_escalate` checks `grievance.jurisdiction.level` for each loaded grievance, leading to an N+1 query bottleneck.
📊 Impact: Expected to significantly reduce database load during bulk evaluation and reduce latency proportional to the number of overdue grievances.
🔬 Measurement: Run a local profiling script to verify queries drop from 1+N to 1 during the `evaluate_and_escalate_grievances` loop.

---
*PR created automatically by Jules for task [15130273495189877102](https://jules.google.com/task/15130273495189877102) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eagerly loads `jurisdiction` when fetching overdue grievances to remove an N+1 query in the EscalationEngine. This drops queries in the evaluation loop from 1+N to 1 and reduces latency as the number of grievances grows.

- **Performance**
  - Use SQLAlchemy `joinedload(Grievance.jurisdiction)` in `_get_grievances_for_evaluation` so `_should_escalate` can read `grievance.jurisdiction.level` without extra queries.

<sup>Written for commit a8f427d299353bc945e70918c45801b6a85d43d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RohanExploit/VishwaGuru/pull/922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

