### PR TITLE
Fix: ActionView crash from missing setActionPlan prop causing pages to fail loading after complaint registration

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate, useNavigate, useLocat
 import ChatWidget from './components/ChatWidget';
 import { issuesApi, miscApi } from './api';
 import { fakeRecentIssues, fakeResponsibilityMap } from './fakeData';
-
+import ErrorBoundary from './components/ErrorBoundary';
 // Lazy-load view components
 const Home = React.lazy(() => import('./views/Home'));
 const MapView = React.lazy(() => import('./views/MapView'));
@@ -274,13 +274,13 @@ function AppContent() {
           </div>
         )}
 
+<ErrorBoundary>
         <Suspense fallback={
           <div className="flex justify-center my-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500"></div>
           </div>
         }>
-          <Routes>
-          <Route path="/home" element={<Navigate to="/" replace />} />
+          <Routes>          <Route path="/home" element={<Navigate to="/" replace />} />
             <Route
               path="/"
               element={
@@ -300,18 +300,18 @@ function AppContent() {
               path="/report"
               element={
                 <ReportForm
-                  setView={navigateToView}
-                  setLoading={setLoading}
-                  setError={setError}
-                  setActionPlan={setActionPlan}
-                  loading={loading}
-                />
+  setView={navigateToView}
+  setLoading={setLoading}
+  setError={setError}
+  setActionPlan={setActionPlan}
+  fetchRecentIssues={fetchRecentIssues}
+  loading={loading}
+/>
               }
             />
             <Route
               path="/action"
-              element={<ActionView actionPlan={actionPlan} setView={navigateToView} />}
-            />
+element={<ActionView actionPlan={actionPlan} setActionPlan={setActionPlan} setView={navigateToView} />}            />
             <Route
               path="/mh-rep"
               element={
@@ -338,9 +338,9 @@ function AppContent() {
             <Route path="/blocked" element={<BlockedRoadDetector onBack={() => navigate('/')} />} />
             <Route path="/tree" element={<TreeDetector onBack={() => navigate('/')} />} />
             <Route path="*" element={<NotFound />} />
-          </Routes>
+</Routes>
         </Suspense>
-      </div>
+        </ErrorBoundary>      </div>
     </div>
   );
 }

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught an error:', error, info);
+  }
+
+  handleReload = () => {
+    this.setState({ hasError: false });
+    window.location.href = '/';
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="mt-6 text-center p-8">
+          <h2 className="text-xl font-bold text-red-700 mb-2">Something went wrong</h2>
+          <p className="text-gray-600 mb-4">This page failed to load. Please go back and try again.</p>
+          <button onClick={this.handleReload} className="text-blue-600 underline">Back to Home</button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/views/ActionView.jsx
+++ b/frontend/src/views/ActionView.jsx
@@ -5,8 +5,15 @@ import StatusTracker from '../components/StatusTracker';
 const API_URL = import.meta.env.VITE_API_URL || '';
 
 const ActionView = ({ actionPlan, setActionPlan, setView }) => {
-  if (!actionPlan) return null;
-
+  if (!actionPlan) {
+    return (
+      <div className="mt-6 text-center p-8">
+        <h2 className="text-xl font-bold text-gray-800 mb-2">No action plan found</h2>
+        <p className="text-gray-600 mb-4">Please submit a complaint first to generate an action plan.</p>
+        <button onClick={() => setView('report')} className="text-blue-600 underline">Go to Report Form</button>
+      </div>
+    );
+  }
   useEffect(() => {
     let interval;
     if (actionPlan.status === 'generating' && actionPlan.id) {
@@ -17,11 +24,14 @@ const ActionView = ({ actionPlan, setActionPlan, setView }) => {
             const data = await res.json();
             // Find the issue by ID
             const issue = data.find(i => i.id === actionPlan.id);
-            if (issue && issue.action_plan && issue.action_plan.whatsapp) {
+if (issue && issue.action_plan && issue.action_plan.whatsapp) {
                // Plan is ready!
-               setActionPlan(issue.action_plan);
-            }
-          }
+               if (typeof setActionPlan === 'function') {
+                 setActionPlan(issue.action_plan);
+               } else {
+                 console.error('ActionView: setActionPlan prop is missing, cannot update action plan.');
+               }
+            }          }
         } catch (e) {
           console.error("Polling error:", e);
         }

--- a/frontend/src/views/ReportForm.jsx
+++ b/frontend/src/views/ReportForm.jsx
@@ -10,8 +10,7 @@ import { detectorsApi } from '../api';
 // Get API URL from environment variable, fallback to relative URL for local dev
 const API_URL = import.meta.env.VITE_API_URL || '';
 
-const ReportForm = ({ setView, setLoading, setError, setActionPlan, loading }) => {
-  const { t, i18n } = useTranslation();
+const ReportForm = ({ setView, setLoading, setError, setActionPlan, fetchRecentIssues, loading }) => {  const { t, i18n } = useTranslation();
   const locationState = useLocation().state || {};
   const [formData, setFormData] = useState({
     description: locationState.description || '',
@@ -350,9 +349,9 @@ const ReportForm = ({ setView, setLoading, setError, setActionPlan, loading }) =
       } else {
         setActionPlan({ id: data.id, status: 'generating' });
       }
-      setSubmitStatus({ state: 'success', message: 'Issue submitted. Preparing your action plan…' });
-      setView('action');
-    } catch (err) {
+setSubmitStatus({ state: 'success', message: 'Issue submitted. Preparing your action plan…' });
+      if (fetchRecentIssues) await fetchRecentIssues();
+      setView('action');    } catch (err) {
       console.error("Submission failed, using fake action plan", err);
       // Fallback to fake action plan on failure
       setActionPlan(fakeActionPlan);


### PR DESCRIPTION
## Summary
Fixes #891 — pages failing to load after a complaint is registered when the action plan isn't immediately ready from the backend.

## Root cause
`App.jsx` renders `<ActionView>` on the `/action` route but only passes the `actionPlan` value, not the `setActionPlan` setter. When a complaint is submitted and the backend hasn't generated the action plan yet, `ActionView` enters a "generating" state and polls `/api/issues/recent` every 2 seconds, calling `setActionPlan(...)` once the plan is ready. Since `setActionPlan` was never passed down, this call throws `setActionPlan is not a function`. There is no error boundary anywhere in the app, so this uncaught error crashes the whole page render instead of failing gracefully — matching the reported "pages failed to load" behavior, specifically when an issue/complaint triggers the async action-plan generation path.

Additionally, the homepage's recent issues list (`recentIssues`) is only fetched once on initial app mount and was never refreshed after a new complaint was submitted, leaving it stale.

## Changes
- Pass the missing `setActionPlan` prop to `ActionView` in `App.jsx`.
- Guard the polling callback in `ActionView.jsx` so a missing/invalid setter logs an error instead of crashing the page.
- Add a proper empty/fallback state in `ActionView.jsx` for when there's no action plan yet, instead of silently rendering nothing.
- Refresh `recentIssues` after a successful complaint submission by passing `fetchRecentIssues` down to `ReportForm`.
- Add a lightweight `ErrorBoundary` component around the app's routes so any future render error shows a friendly fallback UI instead of a blank page.

## Testing
- Verified the fix and root cause against the frontend code directly, tracing the exact prop-passing bug across `App.jsx` and `ActionView.jsx`.
- I ran into some setup trouble getting the Python backend running locally on my machine, so I wasn't able to fully exercise the live end-to-end flow (submit → pending backend response → polling → resolved plan) myself this time. The fix targets the frontend prop-wiring bug directly and is scoped narrowly to that, but I'd appreciate a maintainer or reviewer double-checking the live flow if possible, and I'm happy to iterate on feedback.
- Confirmed the change doesn't touch any other routes (map view, Maharashtra rep view, detectors), so existing functionality should be unaffected.

I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.
Hi @RohanExploit , could you please review this PR for a potential bonus label based on the metrics below? Thanks! 
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/85a9208b-ed39-494d-96fd-8653e67b1869" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash that broke pages after submitting a complaint when the action plan wasn’t ready. Wires the missing `setActionPlan`, adds safe polling and a fallback UI, refreshes recent issues after submit, and wraps routes in an error boundary.

- **Bug Fixes**
  - Pass missing `setActionPlan` to `ActionView` in `App.jsx`.
  - Make `ActionView` resilient: guard polling when the setter is missing and show a clear “No action plan” fallback with a link to the report form.
  - Refresh `recentIssues` after a successful submission by passing and calling `fetchRecentIssues` in `ReportForm`.
  - Wrap routes with `ErrorBoundary` so unexpected errors show a friendly fallback instead of a blank page.

<sup>Written for commit fa8e54ffff7298b50ce8afa4f76a7492992e9272. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RohanExploit/VishwaGuru/pull/932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error handling for route-rendering failures, with a recovery option to return home.
  * Added a clear fallback message when an action plan is unavailable.
  * Improved action-plan updates during WhatsApp processing.
  * Recent issues now refresh after submitting a report before opening the action view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->