### PR TITLE
⚡ Bolt: Resolve N+1 query problem in EscalationEngine

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@
 ## 2025-07-15 - Fast Bounding Box Pre-filter
 **Learning:** Calculating great circle distance (Haversine) for every issue against a target location is computationally expensive (O(N) with heavy math ops like sin, cos, atan2). In high-traffic aggregations, this can become a bottleneck.
 **Action:** Use a fast bounding box pre-filter (`get_bounding_box` with a 5% epsilon) to quickly discard issues that are definitely outside the search radius before running the expensive exact haversine distance calculation.
+## 2025-05-30 - N+1 Query in Escalation Engine
+**Learning:** Evaluating multiple grievances in a loop causes an N+1 query problem when accessing un-loaded relationships like `jurisdiction` inside `_should_escalate`.
+**Action:** Use `joinedload(Grievance.jurisdiction)` during the initial query in `_get_grievances_for_evaluation` to eager load related models and optimize the operation.

--- a/backend/escalation_engine.py
+++ b/backend/escalation_engine.py
@@ -5,7 +5,7 @@ Core engine for evaluating and performing grievance escalations based on SLA and
 
 import datetime
 from typing import List, Dict, Any, Optional
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import and_, or_
 from backend.models import Grievance, Jurisdiction, EscalationAudit, GrievanceStatus, JurisdictionLevel, EscalationReason, SeverityLevel
 from backend.database import SessionLocal
@@ -150,7 +150,7 @@ class EscalationEngine:
         now = datetime.datetime.now(datetime.timezone.utc)
 
         # Get grievances that are active and past SLA deadline
-        return db.query(Grievance).filter(
+        return db.query(Grievance).options(joinedload(Grievance.jurisdiction)).filter(
             and_(
                 Grievance.status.in_([GrievanceStatus.OPEN, GrievanceStatus.IN_PROGRESS, GrievanceStatus.ESCALATED]),
                 Grievance.sla_deadline < now


### PR DESCRIPTION
💡 **What:** Added `joinedload(Grievance.jurisdiction)` to the SQLAlchemy query in `_get_grievances_for_evaluation`.
🎯 **Why:** Previously, evaluating grievances in a loop in `evaluate_and_escalate_grievances` caused an N+1 query problem because `_should_escalate` accesses `grievance.jurisdiction.level`, which triggers an individual SELECT statement for every grievance evaluated.
📊 **Impact:** Reduces database queries from O(N) to O(1) for this specific escalation check, improving the scalability of the background task as the number of grievances increases.
🔬 **Measurement:** Verify by ensuring that `joinedload` successfully eager-loads the related jurisdiction models, preventing the emission of multiple lazy loading SELECT queries in the database logs during SLA evaluation.

---
*PR created automatically by Jules for task [8020252709140725921](https://jules.google.com/task/8020252709140725921) started by @RohanExploit*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eager-load `Grievance.jurisdiction` in `_get_grievances_for_evaluation` using `joinedload` to remove the N+1 query triggered by `grievance.jurisdiction.level` during escalation checks. This reduces DB queries from O(N) to O(1) and speeds up SLA evaluation in the background job.

<sup>Written for commit 001fac1396e4b1adee1e561d762999a1521f1b37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RohanExploit/VishwaGuru/pull/933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

